### PR TITLE
quick start: update the examples to have sync settings on server exit

### DIFF
--- a/catbot.md
+++ b/catbot.md
@@ -28,15 +28,5 @@ The SCM represents a simple cat with just a few behaviors:
 - The cat can count. If you send a message that contains "count", he replies with "1",
   waits a second, then replaces his response with "2", and so on until 10. If you add
   "quickly", he doesn't sleep while counting.
-- If you give him scratches (by sending a message containing "scratch"), he gets so
-  excited that he forgets how the Poe protocol works, and sends back an event with type
-  "purr". (Since this is not allowed by the protocol, it will trigger a call to the
-  `report_error` endpoint from the Poe server.)
 - If you call him a dog, he doesn't want to talk to you any more. If the message
   contains "dog", he turns off suggested replies.
-- If you give him a toy, he keeps hitting it, more than is allowed by the Poe protocol
-  spec. If a message contains "toy", he sends more than 1000 events that contain the
-  text "hit ".
-- If he gets on a bed, he doesn't stop sleeping. If a message contains "bed", he sends a
-  "zzz" response with over 10000 letters, more than the Poe protocol allows.
-- Otherwise, he sleeps. He responds with "zzz".

--- a/catbot.py
+++ b/catbot.py
@@ -110,7 +110,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/catbot.py
+++ b/catbot.py
@@ -10,10 +10,10 @@ of all the protocol has to offer.
 from __future__ import annotations
 
 import asyncio
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 
 class CatBot(fp.PoeBot):
@@ -74,14 +74,6 @@ class CatBot(fp.PoeBot):
                 yield fp.PartialResponse(text=str(i), is_replace_response=True)
                 if "quickly" not in last_message:
                     await asyncio.sleep(1)
-        # These messages make the cat do something that's not allowed by the protocol
-        elif "scratch" in last_message:
-            yield fp.PartialResponse(text="purr")
-        elif "toy" in last_message:
-            for _ in range(1010):
-                yield fp.PartialResponse(text="hit ")
-        elif "bed" in last_message:
-            yield fp.PartialResponse(text="z" * 10_010)
         else:
             yield fp.PartialResponse(text="zzz")
 
@@ -99,22 +91,39 @@ class CatBot(fp.PoeBot):
         )
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46"]
+REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("catbot-poe")
+app = App(name="catbot-poe", image=image)
 
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = CatBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = CatBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/echobot.py
+++ b/echobot.py
@@ -8,10 +8,10 @@ This is the simplest possible bot and a great place to start if you want to buil
 
 from __future__ import annotations
 
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 
 class EchoBot(fp.PoeBot):
@@ -22,22 +22,39 @@ class EchoBot(fp.PoeBot):
         yield fp.PartialResponse(text=last_message)
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46"]
+REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("echobot-poe")
+app = App(name="echobot-poe", image=image)
 
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = EchoBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = EchoBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/echobot.py
+++ b/echobot.py
@@ -41,7 +41,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/function_calling_bot.py
+++ b/function_calling_bot.py
@@ -88,7 +88,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/function_calling_bot.py
+++ b/function_calling_bot.py
@@ -7,10 +7,10 @@ Sample bot that demonstrates how to use OpenAI function calling with the Poe API
 from __future__ import annotations
 
 import json
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 
 def get_current_weather(location, unit="fahrenheit"):
@@ -69,22 +69,39 @@ class GPT35FunctionCallingBot(fp.PoeBot):
         return fp.SettingsResponse(server_bot_dependencies={"GPT-3.5-Turbo": 2})
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46"]
+REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("function-calling-poe")
+app = App(name="function-calling-poe", image=image)
 
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = GPT35FunctionCallingBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = GPT35FunctionCallingBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/http_request_bot.py
+++ b/http_request_bot.py
@@ -49,7 +49,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/http_request_bot.py
+++ b/http_request_bot.py
@@ -7,11 +7,11 @@ Sample bot that shows how to access the HTTP request.
 from __future__ import annotations
 
 import re
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
 from devtools import PrettyFormat
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 pformat = PrettyFormat(width=85)
 
@@ -30,22 +30,39 @@ class HttpRequestBot(fp.PoeBot):
         yield fp.PartialResponse(text="```python\n" + context_string + "\n```")
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46", "devtools==0.12.2"]
+REQUIREMENTS = ["fastapi-poe==0.0.47", "devtools==0.12.2"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("http-request")
+app = App(name="http-request", image=image)
 
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = HttpRequestBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = HttpRequestBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/image_response_bot.py
+++ b/image_response_bot.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 IMAGE_URL = (
     "https://images.pexels.com/photos/46254/leopard-wildcat-big-cat-botswana-46254.jpeg"
@@ -17,22 +17,40 @@ class SampleImageResponseBot(fp.PoeBot):
         yield fp.PartialResponse(text=f"This is a test image. ![leopard]({IMAGE_URL})")
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46"]
+REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("image-response-poe")
+app = App(name="image-response-poe", image=image)
 
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = SampleImageResponseBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
+
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = SampleImageResponseBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/image_response_bot.py
+++ b/image_response_bot.py
@@ -37,7 +37,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/log_bot.py
+++ b/log_bot.py
@@ -46,7 +46,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/pdf_counter_bot.py
+++ b/pdf_counter_bot.py
@@ -65,7 +65,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/pdf_counter_bot.py
+++ b/pdf_counter_bot.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
 import requests
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 from PyPDF2 import PdfReader
 
 
@@ -46,22 +46,39 @@ class PDFSizeBot(fp.PoeBot):
         return fp.SettingsResponse(allow_attachments=True)
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46", "PyPDF2==3.0.1", "requests==2.31.0"]
+REQUIREMENTS = ["fastapi-poe==0.0.47", "PyPDF2==3.0.1", "requests==2.31.0"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("pdf-counter-poe")
+app = App(name="pdf-counter-poe", image=image)
 
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = PDFSizeBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = PDFSizeBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/prompt_bot.py
+++ b/prompt_bot.py
@@ -51,7 +51,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/prompt_bot.py
+++ b/prompt_bot.py
@@ -6,10 +6,10 @@ Sample bot that wraps Claude-3-Haiku but makes responses Haikus
 
 from __future__ import annotations
 
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 SYSTEM_PROMPT = """
 All your replies are Haikus.
@@ -34,20 +34,37 @@ class PromptBot(fp.PoeBot):
 
 REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("prompt-bot-poe")
+app = App(name="prompt-bot-poe", image=image)
 
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = PromptBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = PromptBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-fastapi-poe==0.0.46
+fastapi-poe==0.0.47

--- a/turbo_allcapsbot.py
+++ b/turbo_allcapsbot.py
@@ -6,10 +6,10 @@ Sample bot that wraps GPT-3.5-Turbo but makes responses use all-caps.
 
 from __future__ import annotations
 
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 
 class GPT35TurboAllCapsBot(fp.PoeBot):
@@ -25,22 +25,39 @@ class GPT35TurboAllCapsBot(fp.PoeBot):
         return fp.SettingsResponse(server_bot_dependencies={"GPT-3.5-Turbo": 1})
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46"]
+REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("turbo-allcaps-poe")
+app = App(name="turbo-allcaps-poe", image=image)
 
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = GPT35TurboAllCapsBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = GPT35TurboAllCapsBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/turbo_allcapsbot.py
+++ b/turbo_allcapsbot.py
@@ -44,7 +44,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/turbo_vs_claude.py
+++ b/turbo_vs_claude.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 import asyncio
 import re
 from collections import defaultdict
-from typing import AsyncIterable, AsyncIterator
+from typing import AsyncIterable, AsyncIterator, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, asgi_app
+from modal import App, Image, asgi_app, exit
 
 
 async def combine_streams(
@@ -124,22 +124,40 @@ class GPT35TurbovsClaudeBot(fp.PoeBot):
         )
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46"]
+REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = Image.debian_slim().pip_install(*REQUIREMENTS)
-app = App("turbo-vs-claude-poe")
+app = App(name="turbo-vs-claude-poe", image=image)
 
+@app.cls()
+class Model:
+    # Both of these values are optional, but it is strongly recommended to set them.
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = None # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
 
-@app.function(image=image)
-@asgi_app()
-def fastapi_app():
-    bot = GPT35TurbovsClaudeBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    # POE_ACCESS_KEY = ""
-    # app = make_app(bot, access_key=POE_ACCESS_KEY)
-    app = fp.make_app(bot, allow_without_key=True)
-    return app
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = GPT35TurbovsClaudeBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/turbo_vs_claude.py
+++ b/turbo_vs_claude.py
@@ -144,7 +144,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/video_bot.py
+++ b/video_bot.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
-from typing import AsyncIterable
+from typing import AsyncIterable, Optional
 
 import fastapi_poe as fp
-from modal import App, Image, Mount, asgi_app
+from modal import App, Image, Mount, asgi_app, exit
 
 
 class VideoBot(fp.PoeBot):
@@ -19,27 +19,44 @@ class VideoBot(fp.PoeBot):
         yield fp.PartialResponse(text="Attached a video.")
 
 
-REQUIREMENTS = ["fastapi-poe==0.0.46"]
+REQUIREMENTS = ["fastapi-poe==0.0.47"]
 image = (
     Image.debian_slim()
     .pip_install(*REQUIREMENTS)
     .env({"POE_ACCESS_KEY": os.environ["POE_ACCESS_KEY"]})
 )
-app = App("video-bot")
+app = App(name="video-bot", image=image, mounts=[Mount.from_local_dir("./assets", remote_path="/root/assets")])
 
 
-@app.function(
-    image=image, mounts=[Mount.from_local_dir("./assets", remote_path="/root/assets")]
-)
-@asgi_app()
-def fastapi_app():
-    bot = VideoBot()
-    # Optionally, provide your Poe access key here:
-    # 1. You can go to https://poe.com/create_bot?server=1 to generate an access key.
-    # 2. We strongly recommend using a key for a production bot to prevent abuse,
-    # but the starter examples disable the key check for convenience.
-    # 3. You can also store your access key on modal.com and retrieve it in this function
-    # by following the instructions at: https://modal.com/docs/guide/secrets
-    POE_ACCESS_KEY = os.environ["POE_ACCESS_KEY"]
-    app = fp.make_app(bot, access_key=POE_ACCESS_KEY)
-    return app
+@app.cls()
+class Model:
+    # See https://creator.poe.com/docs/quick-start#integrating-with-poe to find these values.
+    access_key: Optional[str] = os.environ["POE_ACCESS_KEY"] # REPLACE WITH YOUR ACCESS KEY
+    bot_name: Optional[str] = None # REPLACE WITH YOUR BOT NAME
+
+    @exit()
+    def sync_settings(self):
+        """Syncs bot settings on server shutdown."""
+        if self.bot_name and self.access_key:
+            try:
+                fp.sync_bot_settings(self.bot_name, self.access_key)
+            except Exception:
+                print("\n*********** Warning ***********")
+                print(
+                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                )
+                print("\n*********** Warning ***********")
+
+    @asgi_app()
+    def fastapi_app(self):
+        bot = VideoBot()
+        if not self.access_key:
+            print("Warning: Running without an access key. Please remember to set it before production.")
+            app = fp.make_app(bot, allow_without_key=True)
+        else:
+            app = fp.make_app(bot, access_key=self.access_key)
+        return app
+
+@app.local_entrypoint()
+def main():
+    Model().run.remote()

--- a/video_bot.py
+++ b/video_bot.py
@@ -43,7 +43,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 

--- a/wrapper_bot.py
+++ b/wrapper_bot.py
@@ -78,7 +78,7 @@ class Model:
             except Exception:
                 print("\n*********** Warning ***********")
                 print(
-                    f"Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
+                    "Bot settings sync failed. For more information, see: https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings"
                 )
                 print("\n*********** Warning ***********")
 


### PR DESCRIPTION
this should help to mitigate issue of people forgetting to sync settings (if they follow the quick start and use Modal at least) also, remove some outdated parts of catbot.py