### PR TITLE
Add ClothingRecommenderBot and PythonRunnerBot examples to README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 repos:
+  # Order matters because pyupgrade may make changes that pycln and black have to clean up
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.0
     hooks:
@@ -9,7 +10,7 @@ repos:
     rev: v2.5.0
     hooks:
       - id: pycln
-        args: ["--config=pyproject.toml"]
+        args: [--config=pyproject.toml]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 repos:
-  # Order matters because pyupgrade may make changes that pycln and black have to clean up
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.19.0
     hooks:
@@ -7,10 +6,10 @@ repos:
         args: [--py37-plus]
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: pycln
-        args: [--config=./pyproject.toml]
+        args: ["--config=pyproject.toml"]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v2.4.0
     hooks:
       - id: pycln
-        args: [--config=pyproject.toml]
+        args: [--config=./pyproject.toml]
 
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/README.md
+++ b/README.md
@@ -138,3 +138,23 @@ A correct implementation would look like https://poe.com/AllCapsBotDemo
   [here](https://creator.poe.com/docs/server-bots-functional-guides#updating-bot-settings).
 
 A correct implementation would look like https://poe.com/TurboVsClaudeBotDemo
+
+### ClothingRecommenderBot
+
+- An example bot that takes in a user-uploaded image, analyzes it with Claude-3.5-Sonnet
+  to recommend a new top, and then generates an image of the new clothing with Imagen-3
+  to return to the user.
+- This is a good starting point for handling user-uploaded attachments, and also
+  returning attachments with your bot.
+- To deploy, run `modal deploy new_top_recommender.py`
+
+A correct implementation would look like https://poe.com/TopRecommender
+
+### PythonRunnerBot
+
+- An example bot that generates code based on the user query, runs it with the @Python
+  bot, and attempts to debug it if there's any issue.
+- This is a good starting point for chaining requests to various text models.
+- To deploy, run `modal deploy python_runner.py`
+
+A correct implementation would look like https://poe.com/PythonCodeRunner

--- a/new_top_recommender.py
+++ b/new_top_recommender.py
@@ -113,7 +113,10 @@ class OutfitRecommenderBot(fp.PoeBot):
             is_inline=True,
         )
         yield fp.PartialResponse(
-            text=f"\n\nHere's an image of the recommended top![new_top][{attachment_response.inline_ref}]"
+            text=(
+                "\n\nHere's an image of the recommended top![new_top]["
+                f"{attachment_response.inline_ref}]"
+            )
         )
 
     async def get_settings(self, setting: fp.SettingsRequest) -> fp.SettingsResponse:

--- a/python_runner.py
+++ b/python_runner.py
@@ -69,7 +69,8 @@ class CodeGenAndRunnerBot(fp.PoeBot):
             yield fp.PartialResponse(text=msg.text)
         yield fp.PartialResponse(text="\n```")
 
-        # Clean up code snippet by removing triple backticks in case Claude ignored the instructions.
+        # Clean up code snippet by removing triple backticks 
+        # This is incase Claude ignored the instructions.
         code_snippet = re.sub(r"```+", "", code_snippet).strip()
 
         # -------------

--- a/python_runner.py
+++ b/python_runner.py
@@ -42,14 +42,18 @@ class CodeGenAndRunnerBot(fp.PoeBot):
         # -------------
         # 1) Ask Claude-3.5-Sonnet to generate code
         # -------------
-        yield fp.PartialResponse(text="Generating code with Claude-3.5-Sonnet...\n")
+        yield fp.PartialResponse(
+            text="Generating code with Claude-3.5-Sonnet...\n"
+        )
         # We'll give it the user's message: user_message
         # Let’s define a prompt that instructs Claude to produce Python code:
         gen_code_prompt = (
             "You are a helpful coding assistant. The user wants some Python code. "
-            "Please provide only the Python code (no markdown fences) needed to accomplish the following request:\n\n"
+            "Please provide only the Python code (no markdown fences) needed to "
+            "accomplish the following request:\n\n"
             f"{user_message}\n\n"
-            "Do not include any comments or other text in the code. Do not offer to explain the code."
+            "Do not include any comments or other text in the code. Do not offer to "
+            "explain the code."
         )
 
         # Wrap the code in triple backticks for nice formatting
@@ -80,22 +84,27 @@ class CodeGenAndRunnerBot(fp.PoeBot):
         # Check if Python returned an error by looking for "Traceback" or "Error" keywords
         error_keywords = ["Traceback (most recent call last):", "Error:"]
         has_error = any(keyword in python_result for keyword in error_keywords)
-        yield fp.PartialResponse(text=f"Output of code:\n{python_result}")
+        yield fp.PartialResponse(
+            text=f"Output of code:\n{python_result}"
+        )
 
         # -------------
         # 3) If there's an error, call Claude to help debug
         # -------------
         if has_error:
             yield fp.PartialResponse(
-                text=f"\nWe got an error when running the code. Asking Claude-3.5-Sonnet to debug...\n"
+                text="\nWe got an error when running the code. Asking "
+                "Claude-3.5-Sonnet to debug...\n"
             )
 
             debug_prompt = (
                 "The following Python code produced an error. "
                 f"Original code:\n{code_snippet}\n\n"
                 f"Error:\n{python_result}\n\n"
-                "Please provide only the Python code (no markdown fences) needed to fix the error."
-                "Do not include any comments or other text in the code. Do not offer to explain the code."
+                "Please provide only the Python code (no markdown fences) needed to "
+                "fix the error."
+                " Do not include any comments or other text in the code. "
+                "Do not offer to explain the code."
             )
             debug_code_snippet = ""
             yield fp.PartialResponse(text="```python\n")
@@ -148,8 +157,9 @@ class CodeGenAndRunnerBot(fp.PoeBot):
                     "But we got an error. So we debugged it and ran the following code:\n"
                     f"{debug_code_snippet}\n\n"
                     "The output of the code was:\n"
-                    f"{python_debug_result}"
-                    "Please summarize the output of the code, and whether it fulfilled the original request."
+                    f"{python_debug_result}\n\n"
+                    "Please summarize the output of the code, and whether it fulfilled the "
+                    "original request."
                 )
 
                 async for msg in fp.stream_request(
@@ -175,8 +185,9 @@ class CodeGenAndRunnerBot(fp.PoeBot):
                 "The code that was generated and run was:\n"
                 f"{code_snippet}\n\n"
                 "The output of the code was:\n"
-                f"{python_result}"
-                "Please summarize the output of the code, and whether it fulfilled the original request."
+                f"{python_result}\n\n"
+                "Please summarize the output of the code, and whether it fulfilled the "
+                "original request."
             )
 
             async for msg in fp.stream_request(


### PR DESCRIPTION
This PR updates the README with the two new example bots added earlier today, following the conventions for the other examples in the README  🚀

### ClothingRecommenderBot

- An example bot that takes in a user-uploaded image, analyzes it with Claude-3.5-Sonnet
  to recommend a new top, and then generates an image of the new clothing with Imagen-3
  to return to the user.
- This is a good starting point for handling user-uploaded attachments, and also
  returning attachments with your bot.
- To deploy, run `modal deploy new_top_recommender.py`

A correct implementation would look like https://poe.com/TopRecommender

---

### PythonRunnerBot

- An example bot that generates code based on the user query, runs it with the @Python
  bot, and attempts to debug it if there's any issue.
- This is a good starting point for chaining requests to various text models.
- To deploy, run `modal deploy python_runner.py`

A correct implementation would look like https://poe.com/PythonCodeRunner